### PR TITLE
error with use reserved characters

### DIFF
--- a/classes/MainAdminController.php
+++ b/classes/MainAdminController.php
@@ -173,7 +173,9 @@ class MainAdminController extends Controller
             'hasCheckboxes' => $this->config['pagedata_attribute'] !== '',
             'dataURL' => (string) $url->with('pagemanager', '')->with('admin', 'plugin_main')
                 ->with('action', 'plugin_data')->with('edit', ''),
-            'uriCharOrg' => explode(XH_URICHAR_SEPARATOR, $tx['urichar']['org']),
+            'uriCharOrg' => explode(XH_URICHAR_SEPARATOR, str_replace(array('?', '*', '+', '(', ')'),
+                                                                      array('\?', '\*', '\+', '\(', '\)'),
+                                                                      $tx['urichar']['org'])),
             'uriCharNew' => explode(XH_URICHAR_SEPARATOR, $tx['urichar']['new'])
         );
         return json_encode($config);


### PR DESCRIPTION
Many problems because reserved characters are not excluded or replaced.
In case of an update it does not come into effect, so it does not cause any problems and in case of a new installation it would be possible.

https://github.com/cmsimple-xh/cmsimple-xh/issues/413

If all reserved characters are replaced with $tx['urichar']['org'], $tx['urichar']['new'], then under certain situations the page manager will delete the complete content of the content.html.

https://github.com/cmb69/pagemanager_xh/issues/63